### PR TITLE
Add docker-compose.yml to run exporter

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: '3.8'
+
+services:
+  sb8200_exporter:
+    image: chaoscorp/sb8200-exporter:latest
+    container_name: sb8200-exporter
+    environment:
+      SB8200_PASS: ${SB8200_PASS}
+      SB8200_USER: ${SB8200_USER:-Admin}
+      SB8200_URL: ${SB8200_URL:-http://192.168.100.1}
+    ports:
+      - "9800:9800"
+    restart: unless-stopped


### PR DESCRIPTION
This pull request adds a `docker-compose.yml` file that defines a service for running the SB8200 Prometheus exporter in Docker.

The compose file includes:

- The `chaoscorp/sb8200-exporter:latest` image
- Environment variables for modem URL, user and password (to be set via `.env` or host environment)
- Port mapping to expose the exporter at port 9800
- A restart policy of `unless-stopped`

This makes it easy to deploy the exporter alongside other services using Docker Compose.